### PR TITLE
Bugfixing reader for http streams

### DIFF
--- a/reader/http/http.c
+++ b/reader/http/http.c
@@ -832,7 +832,9 @@ static size_t http_read (void *ptr, size_t size, void *d)
     pthread_mutex_init (&mut, NULL);
 
     /* check for reopen */
-    if (desc->begin > desc->pos || desc->begin + desc->len + 3*HTTP_BLOCK_SIZE < desc->pos)
+    if (desc->begin > desc->pos 
+	    || desc->begin + desc->len + 3*HTTP_BLOCK_SIZE < desc->pos
+	    || (!desc->going && desc->pos < desc->size))
 	reconnect (desc, NULL);
 
     /* wait while the buffer will has entire block */

--- a/reader/http/http.c
+++ b/reader/http/http.c
@@ -572,7 +572,8 @@ static int reconnect (http_desc_t *desc, char *redirect)
 			     desc->pos);
     //alsaplayer_error("%s", request);
     write (desc->sock, request, strlen (request));
-    desc->begin = desc->buffer_pos = desc->pos;
+    desc->begin = desc->pos;
+    desc->buffer_pos = 0;
 
     /* Get response */
     if (get_response_head (desc->sock, response, 10240))


### PR DESCRIPTION
There were two issues playing some internet radio streams: One will lead to seg fault during the first few seconds when playing the stream. The second will stall the player if the server closes the connection.

The first issue happens if the stream is seekable and the mad input plugin tries to move to the end of the stream to read id3v1 tags. When this happens a new request is started at the last 128 bytes of the stream. Because the buffer_pos was set to this position the icy metadata calculation failed and caused a segmentation fault. (exactly at https://github.com/alsaplayer/alsaplayer/blob/master/reader/http/http.c#L399)

The second issue applies to the case when the server allows only one connection at a time. When the streams starts playing, a second connection will be established from the mad input plugin to read the id3 tags. This might lead to closing the first connection for the audio stream by the server. Now the buffer thread quits, but the http_read method gets repeatedly called without success. The fix will reconnect if the http_read method sees that the buffer thread is not alive and the eof is not reached.

