### PR TITLE
Add missing #include in libmikmod configure test

### DIFF
--- a/m4/libmikmod.m4
+++ b/m4/libmikmod.m4
@@ -64,6 +64,7 @@ dnl
 #include <mikmod.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 char* my_strdup (char *str)
 {


### PR DESCRIPTION
GCC 14 treats missing prototypes as an error by default, so this test would always fail.